### PR TITLE
Pytest 4 compatibility

### DIFF
--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -104,12 +104,12 @@ def get_testrail_keys(items):
     """Return Tuple of Pytest nodes and TestRail ids from pytests markers"""
     testcaseids = []
     for item in items:
-        if item.get_marker(TESTRAIL_PREFIX):
+        if item.get_closest_marker(TESTRAIL_PREFIX):
             testcaseids.append(
                 (
                     item,
                     clean_test_ids(
-                        item.get_marker(TESTRAIL_PREFIX).kwargs.get('ids')
+                        item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get('ids')
                     )
                 )
             )
@@ -182,13 +182,13 @@ class PyTestRailPlugin(object):
         """ Collect result and associated testcases (TestRail) of an execution """
         outcome = yield
         rep = outcome.get_result()
-        if item.get_marker(TESTRAIL_PREFIX):
-            testcaseids = item.get_marker(TESTRAIL_PREFIX).kwargs.get('ids')
+        if item.get_closest_marker(TESTRAIL_PREFIX):
+            testcaseids = item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get('ids')
 
             if rep.when == 'call' and testcaseids:
                 self.add_result(
                     clean_test_ids(testcaseids),
-                    get_test_outcome(outcome.result.outcome),
+                    get_test_outcome(outcome.get_result().outcome),
                     comment=rep.longrepr,
                     duration=rep.duration
                 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name='pytest-testrail',
     description='pytest plugin for creating TestRail runs and adding results',
     long_description=read_file('README.rst'),
-    version='2.3.1',
+    version='2.3.2',
     author='Allan Kilpatrick',
     author_email='allanklp@gmail.com',
     url='http://github.com/allankp/pytest-testrail/',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     ],
     package_dir={'pytest_testrail': 'pytest_testrail'},
     install_requires=[
-        'pytest>=2',
+        'pytest>=3.6',
         'requests>=2.20.0',
         'simplejson',
     ],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -338,8 +338,8 @@ def test_skip_missing_only_one_test(api_client, pytest_test_items):
 
     my_plugin.pytest_collection_modifyitems(None, None, pytest_test_items)
 
-    assert not pytest_test_items[0].get_marker('skip')
-    assert pytest_test_items[1].get_marker('skip')
+    assert not pytest_test_items[0].get_closest_marker('skip')
+    assert pytest_test_items[1].get_closest_marker('skip')
 
 
 def test_skip_missing_correlation_tests(api_client, pytest_test_items):
@@ -357,5 +357,5 @@ def test_skip_missing_correlation_tests(api_client, pytest_test_items):
 
     my_plugin.pytest_collection_modifyitems(None, None, pytest_test_items)
 
-    assert not pytest_test_items[0].get_marker('skip')
-    assert not pytest_test_items[1].get_marker('skip')
+    assert not pytest_test_items[0].get_closest_marker('skip')
+    assert not pytest_test_items[1].get_closest_marker('skip')


### PR DESCRIPTION
* Change functions removed in Pytest 4 
* Remove warnings due to deprecated functions

Restriction: Pytest >= 3.6
