### PR TITLE
register mark testrail to avoid the pytest warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+
+markers =
+    testrail


### PR DESCRIPTION
This aims to avoid this warning

```
venv/lib/python3.7/site-packages/_pytest/mark/structures.py:337
  /Users/thanhnguyen/Desktop/conan/venv/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.testrail - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```