### PR TITLE
add milestone id to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,5 @@ py.test --testrail --tr-config=<settings file>.cfg
                         Do not publish results of "blocked" testcases in
                         TestRail
   --tr-skip-missing     Skip test cases that are not present in testrun
+  --tr-milestone-id     Identifier of milestone to be assigned to run
 ```

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -96,6 +96,13 @@ def pytest_addoption(parser):
         action='store_true',
         required=False,
         help='Skip test cases that are not present in testrun')
+    group.addoption(
+        '--tr-milestone-id',
+        action='store',
+        default=None,
+        required=False,
+        help='Identifier of milestone, to be used in run creation (config file: milestone_id in TESTRUN section)'
+    )
 
 def pytest_configure(config):
     if config.getoption('--testrail'):
@@ -119,7 +126,8 @@ def pytest_configure(config):
                 version=config.getoption('--tr-version'),
                 close_on_complete=config.getoption('--tr-close-on-complete'),
                 publish_blocked=config.getoption('--tr-dont-publish-blocked'),
-                skip_missing=config.getoption('--tr-skip-missing')
+                skip_missing=config.getoption('--tr-skip-missing'),
+                milestone_id=config_manager.getoption('tr-milestone-id', 'milestone_id', 'TESTRUN')
             ),
             # Name of plugin instance (allow to be used by other plugins)
             name="pytest-testrail-instance"

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -118,7 +118,8 @@ def get_testrail_keys(items):
 
 class PyTestRailPlugin(object):
     def __init__(self, client, assign_user_id, project_id, suite_id, include_all, cert_check, tr_name, run_id=0,
-                 plan_id=0, version='', close_on_complete=False, publish_blocked=True, skip_missing=False):
+                 plan_id=0, version='', close_on_complete=False, publish_blocked=True, skip_missing=False,
+                 milestone_id=None):
         self.assign_user_id = assign_user_id
         self.cert_check = cert_check
         self.client = client
@@ -133,6 +134,7 @@ class PyTestRailPlugin(object):
         self.close_on_complete = close_on_complete
         self.publish_blocked = publish_blocked
         self.skip_missing = skip_missing
+        self.milestone_id = milestone_id
 
     # pytest hooks
 
@@ -174,7 +176,8 @@ class PyTestRailPlugin(object):
                 self.suite_id,
                 self.include_all,
                 self.testrun_name,
-                tr_keys
+                tr_keys,
+                self.milestone_id
             )
 
     @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -295,7 +298,7 @@ class PyTestRailPlugin(object):
             print('[{}] Info: Testcases not published for following reason: "{}"'.format(TESTRAIL_PREFIX, error))
 
     def create_test_run(
-            self, assign_user_id, project_id, suite_id, include_all, testrun_name, tr_keys):
+            self, assign_user_id, project_id, suite_id, include_all, testrun_name, tr_keys, milestone_id):
         """
         Create testrun with ids collected from markers.
 
@@ -307,6 +310,7 @@ class PyTestRailPlugin(object):
             'assignedto_id': assign_user_id,
             'include_all': include_all,
             'case_ids': tr_keys,
+            'milestone_id': milestone_id
         }
 
         response = self.client.send_post(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -13,6 +13,7 @@ pytest_plugins = "pytester"
 
 ASSIGN_USER_ID = 3
 FAKE_NOW = datetime(2015, 1, 31, 19, 5, 42)
+MILESTONE_ID = 5
 PROJECT_ID = 4
 PYTEST_FILE = """
     from pytest_testrail.plugin import testrail, pytestrail
@@ -63,7 +64,8 @@ def api_client():
 
 @pytest.fixture
 def tr_plugin(api_client):
-    return PyTestRailPlugin(api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, False, True, TR_NAME, version='1.0.0.0')
+    return PyTestRailPlugin(api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, False, True, TR_NAME, version='1.0.0.0',
+                            milestone_id=MILESTONE_ID)
 
 
 @pytest.fixture
@@ -209,7 +211,8 @@ def test_create_test_run(api_client, tr_plugin, include_all):
     expected_tr_keys = [3453, 234234, 12]
     expect_name = 'testrun_name'
 
-    tr_plugin.create_test_run(ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, include_all, expect_name, expected_tr_keys)
+    tr_plugin.create_test_run(ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, include_all, expect_name, expected_tr_keys,
+                              MILESTONE_ID)
 
     expected_uri = plugin.ADD_TESTRUN_URL.format(PROJECT_ID)
     expected_data = {
@@ -217,7 +220,8 @@ def test_create_test_run(api_client, tr_plugin, include_all):
         'name': expect_name,
         'assignedto_id': ASSIGN_USER_ID,
         'include_all': include_all,
-        'case_ids': expected_tr_keys
+        'case_ids': expected_tr_keys,
+        'milestone_id': MILESTONE_ID
     }
     check_cert = True
     api_client.send_post.assert_called_once_with(expected_uri, expected_data, cert_check=check_cert)


### PR DESCRIPTION
Adding cfg file and cmd line support to allow a milestone to be added to a run on a new run creation https://github.com/allankp/pytest-testrail/issues/87