### PR TITLE
add the ability to extend the comment of test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ project_id = 2
 suite_id = 3
 plan_id = 4
 description = 'This is an example description'
+
+[TESTCASE]
+custom_comment = 'This is a custom comment'
 ```
 
 Or
@@ -104,3 +107,4 @@ py.test --testrail --tr-config=<settings file>.cfg
 | --tr-dont-publish-blocked      | Do not publish results of "blocked" testcases in TestRail                                                           |
 | --tr-skip-missing              | Skip test cases that are not present in testrun                                                                     |
 |  --tr-milestone-id             | Identifier of milestone to be assigned to run                                                                       |
+| --tc-custom-comment            | Custom comment, to be appended to default comment for test case (config file: custom_comment in TESTCASE section) |

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -111,6 +111,13 @@ def pytest_addoption(parser):
         required=False,
         help='Identifier of milestone, to be used in run creation (config file: milestone_id in TESTRUN section)'
     )
+    group.addoption(
+        '--tc-custom-comment',
+        action='store',
+        default=None,
+        required=False,
+        help='Custom comment, to be appended to default comment for test case (config file: custom_comment in TESTCASE section)'
+    )
 
 
 def pytest_configure(config):
@@ -140,7 +147,8 @@ def pytest_configure(config):
                 close_on_complete=config.getoption('--tr-close-on-complete'),
                 publish_blocked=config.getoption('--tr-dont-publish-blocked'),
                 skip_missing=config.getoption('--tr-skip-missing'),
-                milestone_id=config_manager.getoption('tr-milestone-id', 'milestone_id', 'TESTRUN')
+                milestone_id=config_manager.getoption('tr-milestone-id', 'milestone_id', 'TESTRUN'),
+                custom_comment=config_manager.getoption('--tc-custom-comment', 'custom_comment', 'TESTCASE')
             ),
             # Name of plugin instance (allow to be used by other plugins)
             name="pytest-testrail-instance"

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -158,7 +158,7 @@ class PyTestRailPlugin(object):
         self.publish_blocked = publish_blocked
         self.skip_missing = skip_missing
         self.milestone_id = milestone_id
-        self.comment = custom_comment
+        self.custom_comment = custom_comment
 
     # pytest hooks
 
@@ -318,8 +318,8 @@ class PyTestRailPlugin(object):
                 entry['version'] = self.version
             comment = result.get('comment', '')
             if comment:
-                if self.comment:
-                    entry['comment'] = self.comment + '\n'
+                if self.custom_comment:
+                    entry['comment'] = self.custom_comment + '\n'
                     # Indent text to avoid string formatting by TestRail. Limit size of comment.
                     entry['comment'] += u"# Pytest result: #\n"
                     entry['comment'] += u'Log truncated\n...\n' if len(str(comment)) > COMMENT_SIZE_LIMIT else u''
@@ -330,7 +330,7 @@ class PyTestRailPlugin(object):
                     entry['comment'] += u'Log truncated\n...\n' if len(str(comment)) > COMMENT_SIZE_LIMIT else u''
                     entry['comment'] += u"    " + converter(str(comment), "utf-8")[-COMMENT_SIZE_LIMIT:].replace('\n', '\n    ')
             elif comment == '':
-                entry['comment'] = self.comment
+                entry['comment'] = self.custom_comment
             duration = result.get('duration')
             if duration:
                 duration = 1 if (duration < 1) else int(round(duration))  # TestRail API doesn't manage milliseconds

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -180,19 +180,12 @@ def test_pytest_sessionfinish(api_client, tr_plugin):
     tr_plugin.pytest_sessionfinish(None, 0)
 
     expected_data = {'results': [
-<<<<<<< HEAD
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'defects':'PF-516', 'version': '1.0.0.0', 'elapsed': '3s'},
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'defects':['PF-517', 'PF-113'], 'version': '1.0.0.0', 'elapsed': '3s'},
-        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'defects':None, 'version': '1.0.0.0', 'elapsed': '1s',
-         'comment': "# Pytest result: #\n    An error"}
-=======
         {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'defects':'PF-516', 'version': '1.0.0.0', 'elapsed': '3s',
          'comment': CUSTOM_COMMENT},
         {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'defects':['PF-517', 'PF-113'], 'version': '1.0.0.0', 'elapsed': '3s',
          'comment': CUSTOM_COMMENT},
         {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'defects':None, 'version': '1.0.0.0', 'elapsed': '1s',
          'comment': u'{}\n# Pytest result: #\n    An error'.format(CUSTOM_COMMENT)}
->>>>>>> add the ability to extend the comment of test case
     ]}
 
     api_client.send_post.assert_any_call(plugin.ADD_RESULTS_URL.format(tr_plugin.testrun_id), expected_data,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -171,8 +171,8 @@ def test_pytest_runtest_makereport(pytest_test_items, tr_plugin, testdir):
 
 def test_pytest_sessionfinish(api_client, tr_plugin):
     tr_plugin.results = [
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'duration': 2.6, 'defects':'PF-516'},
-        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'comment': "An error", 'duration': 0.1, 'defects':None},
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'duration': 2.6, 'defects':'PF-516' },
+        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'comment': "An error", 'duration': 0.1, 'defects':None },
         {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'duration': 2.6, 'defects': ['PF-517', 'PF-113']}
     ]
     tr_plugin.testrun_id = 10
@@ -180,16 +180,14 @@ def test_pytest_sessionfinish(api_client, tr_plugin):
     tr_plugin.pytest_sessionfinish(None, 0)
 
     expected_data = {'results': [
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'defects':'PF-516', 'version': '1.0.0.0', 'elapsed': '3s',
-         'comment': CUSTOM_COMMENT},
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'defects':['PF-517', 'PF-113'], 'version': '1.0.0.0', 'elapsed': '3s',
-         'comment': CUSTOM_COMMENT},
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'defects':'PF-516', 'version': '1.0.0.0', 'elapsed': '3s', 'comment': CUSTOM_COMMENT},
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'defects':['PF-517', 'PF-113'], 'version': '1.0.0.0', 'elapsed': '3s', 'comment': CUSTOM_COMMENT},
         {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'defects':None, 'version': '1.0.0.0', 'elapsed': '1s',
-         'comment': u'{}\n# Pytest result: #\n    An error'.format(CUSTOM_COMMENT)}
+        'comment': u'{}\n# Pytest result: #\n    An error'.format(CUSTOM_COMMENT)}
     ]}
 
     api_client.send_post.assert_any_call(plugin.ADD_RESULTS_URL.format(tr_plugin.testrun_id), expected_data,
-                                         cert_check=True)
+                                        cert_check=True)
 
 
 def test_pytest_sessionfinish_testplan(api_client, tr_plugin):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -56,6 +56,7 @@ TESTPLAN = {
     }]
 }
 
+CUSTOM_COMMENT = "This is custom comment"
 
 @pytest.fixture
 def api_client():
@@ -66,8 +67,8 @@ def api_client():
 
 @pytest.fixture
 def tr_plugin(api_client):
-    return PyTestRailPlugin(api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, False, True, TR_NAME, DESCRIPTION, version='1.0.0.0', 
-                            milestone_id=MILESTONE_ID)
+    return PyTestRailPlugin(api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, False, True, TR_NAME, DESCRIPTION, version='1.0.0.0',
+                            milestone_id=MILESTONE_ID, custom_comment=CUSTOM_COMMENT)
 
 
 @pytest.fixture
@@ -179,10 +180,19 @@ def test_pytest_sessionfinish(api_client, tr_plugin):
     tr_plugin.pytest_sessionfinish(None, 0)
 
     expected_data = {'results': [
+<<<<<<< HEAD
         {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'defects':'PF-516', 'version': '1.0.0.0', 'elapsed': '3s'},
         {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'defects':['PF-517', 'PF-113'], 'version': '1.0.0.0', 'elapsed': '3s'},
         {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'defects':None, 'version': '1.0.0.0', 'elapsed': '1s',
          'comment': "# Pytest result: #\n    An error"}
+=======
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'defects':'PF-516', 'version': '1.0.0.0', 'elapsed': '3s',
+         'comment': CUSTOM_COMMENT},
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["failed"], 'defects':['PF-517', 'PF-113'], 'version': '1.0.0.0', 'elapsed': '3s',
+         'comment': CUSTOM_COMMENT},
+        {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'defects':None, 'version': '1.0.0.0', 'elapsed': '1s',
+         'comment': u'{}\n# Pytest result: #\n    An error'.format(CUSTOM_COMMENT)}
+>>>>>>> add the ability to extend the comment of test case
     ]}
 
     api_client.send_post.assert_any_call(plugin.ADD_RESULTS_URL.format(tr_plugin.testrun_id), expected_data,
@@ -200,9 +210,10 @@ def test_pytest_sessionfinish_testplan(api_client, tr_plugin):
     api_client.send_get.return_value = TESTPLAN
     tr_plugin.pytest_sessionfinish(None, 0)
     expected_data = {'results': [
-        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'version': '1.0.0.0', 'elapsed': '3s', 'defects':None,},
+        {'case_id': 1234, 'status_id': TESTRAIL_TEST_STATUS["passed"], 'version': '1.0.0.0', 'elapsed': '3s', 'defects':None,
+         'comment': CUSTOM_COMMENT},
         {'case_id': 5678, 'status_id': TESTRAIL_TEST_STATUS["blocked"], 'version': '1.0.0.0', 'elapsed': '1s', 'defects':None,
-         'comment': "# Pytest result: #\n    An error"}
+         'comment': u'{}\n# Pytest result: #\n    An error'.format(CUSTOM_COMMENT)}
     ]}
     print(api_client.send_post.call_args_list)
 


### PR DESCRIPTION
This PR provides:
- if no `custom_comment` is provided, everything stays the same. (empty comment for passed cases, etc.)
- if `custom_comment` is provided, the custom comment string will be added on top of the default comment like `'comment': u'This is custom comment\n# Pytest result: #\n    An error'`

Hope this somehow solve the discussion here https://github.com/allankp/pytest-testrail/issues/45