### PR TITLE
Issue rerun failures

### DIFF
--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -252,7 +252,8 @@ class PyTestRailPlugin(object):
         except NameError:
             converter = lambda s, c: str(bytes(s, "utf-8"), c)
         # Results are sorted by 'case_id' and by 'status_id' (worst result at the end)
-        self.results.sort(key=itemgetter('status_id'))
+        # Comment sort by status_id due to issue with pytest-rerun failures, for details refer to issue https://github.com/allankp/pytest-testrail/issues/100
+        # self.results.sort(key=itemgetter('status_id'))
         self.results.sort(key=itemgetter('case_id'))
 
         # Manage case of "blocked" testcases

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         'pytest>=3.6',
         'requests>=2.20.0',
-        'simplejson',
+        'simplejson', 'freezegun', 'mock'
     ],
     include_package_data=True,
     entry_points={'pytest11': ['pytest-testrail = pytest_testrail.conftest']},


### PR DESCRIPTION
Dear allan,
I would like to submit a PR for the issue when pytest_testrail run with pytest-rerunfailures.
At run time, the last success testcase will be the first submitted to testrail --> makes the test result for that particular test case ( as it will choose the fail run as last result)..
You can refer to #100.
If there is anything need to be done or checked, please tell me.
Thank you!