### PR TITLE
Capture stdout on successful tests

### DIFF
--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -228,7 +228,7 @@ class PyTestRailPlugin(object):
                     self.add_result(
                         clean_test_ids(testcaseids),
                         get_test_outcome(outcome.get_result().outcome),
-                        comment=rep.longrepr,
+                        comment=rep.capstdout,
                         duration=rep.duration
                     )
 

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -216,20 +216,16 @@ class PyTestRailPlugin(object):
         if item.get_closest_marker(TESTRAIL_PREFIX):
             testcaseids = item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get('ids')
             if rep.when == 'call' and testcaseids:
-                if defectids != None:
-                    self.add_result(
-                        clean_test_ids(testcaseids),
-                        get_test_outcome(outcome.get_result().outcome),
-                        comment=rep.longrepr,
+                cleantestids = clean_test_ids(testcaseids)
+                testoutcome = get_test_outcome(outcome.get_result().outcome)
+                testcomment = rep.longrepr if testoutcome != TESTRAIL_TEST_STATUS["passed"] else rep.capstdout
+                testdefects = str(clean_test_defects(defectids)).replace('[', '').replace(']', '').replace("'", '') if defectids != None else None
+                self.add_result(
+                        cleantestids,
+                        testoutcome,
+                        comment=testcomment,
                         duration=rep.duration,
-                        defects=str(clean_test_defects(defectids)).replace('[', '').replace(']', '').replace("'", '')
-                    )
-                else:
-                    self.add_result(
-                        clean_test_ids(testcaseids),
-                        get_test_outcome(outcome.get_result().outcome),
-                        comment=rep.capstdout,
-                        duration=rep.duration
+                        defects=testdefects
                     )
 
     def pytest_sessionfinish(self, session, exitstatus):


### PR DESCRIPTION
This small change allows the user to capture `stdout` on successful tests to the `comment` field in testrails. This can be useful to track results that go beyond a binary PASS/FAIL.

In order to use it in testrails, simply run your pytest with the `--capture=sys` flag to enable capture (see [here](https://docs.pytest.org/en/stable/capture.html))