### PR TITLE
Report stdout in succeeded tests

### DIFF
--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -215,27 +215,21 @@ class PyTestRailPlugin(object):
             test_parametrize = item.callspec.params
         else:
             test_parametrize = None
-        comment = rep.longrepr
         if item.get_closest_marker(TESTRAIL_DEFECTS_PREFIX):
             defectids = item.get_closest_marker(TESTRAIL_DEFECTS_PREFIX).kwargs.get('defect_ids')
         if item.get_closest_marker(TESTRAIL_PREFIX):
             testcaseids = item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get('ids')
             if rep.when == 'call' and testcaseids:
-                if defectids != None:
-                    self.add_result(
-                        clean_test_ids(testcaseids),
-                        get_test_outcome(outcome.get_result().outcome),
-                        comment=comment,
+                cleantestids = clean_test_ids(testcaseids)
+                testoutcome = get_test_outcome(outcome.get_result().outcome)
+                testcomment = rep.longrepr if testoutcome != TESTRAIL_TEST_STATUS["passed"] else rep.capstdout
+                testdefects = str(clean_test_defects(defectids)).replace('[', '').replace(']', '').replace("'", '') if defectids != None else None
+                self.add_result(
+                        cleantestids,
+                        testoutcome,
+                        comment=testcomment,
                         duration=rep.duration,
-                        defects=str(clean_test_defects(defectids)).replace('[', '').replace(']', '').replace("'", ''),
-                        test_parametrize = test_parametrize
-                    )
-                else:
-                    self.add_result(
-                        clean_test_ids(testcaseids),
-                        get_test_outcome(outcome.get_result().outcome),
-                        comment=comment,
-                        duration=rep.duration,
+                        defects=testdefects
                         test_parametrize=test_parametrize
                     )
 


### PR DESCRIPTION
This small change allows the user to capture `stdout` on successful tests to the comment field in testrails. This can be useful to track results that go beyond a binary PASS/FAIL.

In order to use it in testrails, simply run your pytest with the `--capture=sys` flag to enable capture (see here)

Replaces #134 