### PR TITLE
Add option to sort results by status_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,4 @@ Once the all tests are finished they will be updated in TestRail:
 | --tr-skip-missing              | Skip test cases that are not present in testrun                                                                                                    |
 | --tr-milestone-id              | Identifier of milestone to be assigned to run                                                                                                      |
 | --tc-custom-comment            | Custom comment, to be appended to default comment for test case (config file: custom_comment in TESTCASE section)                                  |
+| --tr-sort-by-status-id         | Test results are sorted by status_id, so that worst test result of parametrized test becomes final test status in TestRail                         |

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -121,6 +121,13 @@ def pytest_addoption(parser):
         help='Custom comment, to be appended to default comment for test case \
               (config file: custom_comment in TESTCASE section)'
     )
+    group.addoption(
+        '--tr-sort-by-status-id',
+        action='store_true',
+        default=False,
+        required=False,
+        help='Sort test results by status_id, so the worst test result is final test status in TestRail'
+    )
 
 
 def pytest_configure(config):
@@ -151,7 +158,8 @@ def pytest_configure(config):
                 publish_blocked=config.getoption('--tr-dont-publish-blocked'),
                 skip_missing=config.getoption('--tr-skip-missing'),
                 milestone_id=config_manager.getoption('tr-milestone-id', 'milestone_id', 'TESTRUN'),
-                custom_comment=config_manager.getoption('tc-custom-comment', 'custom_comment', 'TESTCASE')
+                custom_comment=config_manager.getoption('tc-custom-comment', 'custom_comment', 'TESTCASE'),
+                sort_by_status_id=config.getoption('--tr-sort-by-status-id')
             ),
             # Name of plugin instance (allow to be used by other plugins)
             name="pytest-testrail-instance"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,7 @@
 # -*- coding: UTF-8 -*-
 from datetime import datetime
+from operator import itemgetter
+
 from freezegun import freeze_time
 from mock import call, create_autospec
 import pytest
@@ -123,6 +125,47 @@ def test_add_result(tr_plugin):
             'test_parametrize': None
         }
     ]
+
+    assert tr_plugin.results == expected_results
+
+
+def test_add_results_sort_by_status_id(api_client):
+    tr_plugin = PyTestRailPlugin(api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID,
+                                 False, False, TR_NAME, sort_by_status_id=True)
+    tr_plugin.results = [
+        {
+            'case_id': 1234,
+            'status_id': TESTRAIL_TEST_STATUS["blocked"],
+            'duration': 2.6,
+            'defects': None,
+            'comment': 'this is comment'
+        },
+        {
+            'case_id': 1234,
+            'status_id': TESTRAIL_TEST_STATUS["failed"],
+            'duration': 1,
+            'defects': 'PF-516',
+            'comment': 'this is comment'
+        },
+        {
+            'case_id': 5678,
+            'status_id': TESTRAIL_TEST_STATUS["blocked"],
+            'duration': 0.1,
+            'defects': None,
+            'comment': 'this is comment'
+        },
+        {
+            'case_id': 1234,
+            'status_id': TESTRAIL_TEST_STATUS["passed"],
+            'duration': 0.3,
+            'defects': ['PF-517', 'PF-113'],
+            'comment': 'this is comment'
+        }
+    ]
+
+    expected_results = sorted(tr_plugin.results, key=itemgetter("case_id", "status_id"))
+
+    tr_plugin.add_results(testrun_id=10)
 
     assert tr_plugin.results == expected_results
 


### PR DESCRIPTION
Adds an option to sort results by status_id.
This allows to have correct test results in TestRail for parametrized tests with single TestRail ID: test status is fail when test fails for at least one param.
Fixes https://github.com/allankp/pytest-testrail/issues/145