### PR TITLE
Added environmental variable with a link to generated test run

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,25 +85,26 @@ Once the all tests are finished they will be updated in TestRail:
 
 ### All available options
 
-| option                         | description                                                                                                                                        |
-| -------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| --testrail                     | Create and update testruns with TestRail                                                                                                           |
-| --tr-config                    | Path to the config file containing information about the TestRail server (defaults to testrail.cfg)                                                |
-| --tr-url                       | TestRail address you use to access TestRail with your web browser (config file: url in API section)                                                |
-| --tr-email                     | Email for the account on the TestRail server (config file: email in API section)                                                                   |
-| --tr-password                  | Password for the account on the TestRail server (config file: password in API section)                                                             |
-| --tr-testrun-assignedto-id     | ID of the user assigned to the test run (config file:assignedto_id in TESTRUN section)                                                             |
-| --tr-testrun-project-id        | ID of the project the test run is in (config file: project_id in TESTRUN section)                                                                  |
-| --tr-testrun-suite-id          | ID of the test suite containing the test cases (config file: suite_id in TESTRUN section)                                                          |
-| --tr-testrun-suite-include-all | Include all test cases in specified test suite when creating test run (config file: include_all in TESTRUN section)                                |
-| --tr-testrun-name              | Name given to testrun, that appears in TestRail (config file: name in TESTRUN section)                                                             |
-| --tr-testrun-description       | Description given to testrun, that appears in TestRail (config file: description in TESTRUN section)                                               |
-| --tr-run-id                    | Identifier of testrun, that appears in TestRail. If provided, option "--tr-testrun-name" will be ignored                                           |
-| --tr-plan-id                   | Identifier of testplan, that appears in TestRail (config file: plan_id in TESTRUN section) If provided, option "--tr-testrun-name" will be ignored |
-| --tr-version                   | Indicate a version in Test Case result.                                                                                                            |
-| --tr-no-ssl-cert-check         | Do not check for valid SSL certificate on TestRail host                                                                                            |
-| --tr-close-on-complete         | Close a test plan or test run on completion.                                                                                                       |
-| --tr-dont-publish-blocked      | Do not publish results of "blocked" testcases in TestRail                                                                                          |
-| --tr-skip-missing              | Skip test cases that are not present in testrun                                                                                                    |
-| --tr-milestone-id              | Identifier of milestone to be assigned to run                                                                                                      |
-| --tc-custom-comment            | Custom comment, to be appended to default comment for test case (config file: custom_comment in TESTCASE section)                                  |
+| option                         | description                                                                                                                                                               |
+| -------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --testrail                     | Create and update testruns with TestRail                                                                                                                                  |
+| --tr-config                    | Path to the config file containing information about the TestRail server (defaults to testrail.cfg)                                                                       |
+| --tr-url                       | TestRail address you use to access TestRail with your web browser (config file: url in API section)                                                                       |
+| --tr-email                     | Email for the account on the TestRail server (config file: email in API section)                                                                                          |
+| --tr-password                  | Password for the account on the TestRail server (config file: password in API section)                                                                                    |
+| --tr-testrun-assignedto-id     | ID of the user assigned to the test run (config file:assignedto_id in TESTRUN section)                                                                                    |
+| --tr-testrun-project-id        | ID of the project the test run is in (config file: project_id in TESTRUN section)                                                                                         |
+| --tr-testrun-suite-id          | ID of the test suite containing the test cases (config file: suite_id in TESTRUN section)                                                                                 |
+| --tr-testrun-suite-include-all | Include all test cases in specified test suite when creating test run (config file: include_all in TESTRUN section)                                                       |
+| --tr-testrun-name              | Name given to testrun, that appears in TestRail (config file: name in TESTRUN section)                                                                                    |
+| --tr-testrun-description       | Description given to testrun, that appears in TestRail (config file: description in TESTRUN section)                                                                      |
+| --tr-run-id                    | Identifier of testrun, that appears in TestRail. If provided, option "--tr-testrun-name" will be ignored                                                                  |
+| --tr-plan-id                   | Identifier of testplan, that appears in TestRail (config file: plan_id in TESTRUN section) If provided, option "--tr-testrun-name" will be ignored                        |
+| --tr-version                   | Indicate a version in Test Case result.                                                                                                                                   |
+| --tr-no-ssl-cert-check         | Do not check for valid SSL certificate on TestRail host                                                                                                                   |
+| --tr-close-on-complete         | Close a test plan or test run on completion.                                                                                                                              |
+| --tr-dont-publish-blocked      | Do not publish results of "blocked" testcases in TestRail                                                                                                                 |
+| --tr-skip-missing              | Skip test cases that are not present in testrun                                                                                                                           |
+| --tr-milestone-id              | Identifier of milestone to be assigned to run                                                                                                                             |
+| --tc-custom-comment            | Custom comment, to be appended to default comment for test case (config file: custom_comment in TESTCASE section)                                                         |
+| --tr-generate-testrun-link     | Set PYTEST_TESTRAIL_TESTRUN_LINK environment variable that contains link to generated TESTRUN for external usage (i.e. can be used in test reports or notifications)      |

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -121,6 +121,12 @@ def pytest_addoption(parser):
         help='Custom comment, to be appended to default comment for test case \
               (config file: custom_comment in TESTCASE section)'
     )
+    group.addoption(
+        '--tr-generate-testrun-link',
+        action='store_true',
+        help='Set PYTEST_TESTRAIL_TESTRUN_LINK environment variable with a link to generated TESTRUN \
+              for external usage (i.e. can be used in test reports or notifications)'
+    )
 
 
 def pytest_configure(config):
@@ -151,7 +157,8 @@ def pytest_configure(config):
                 publish_blocked=config.getoption('--tr-dont-publish-blocked'),
                 skip_missing=config.getoption('--tr-skip-missing'),
                 milestone_id=config_manager.getoption('tr-milestone-id', 'milestone_id', 'TESTRUN'),
-                custom_comment=config_manager.getoption('tc-custom-comment', 'custom_comment', 'TESTCASE')
+                custom_comment=config_manager.getoption('tc-custom-comment', 'custom_comment', 'TESTCASE'),
+                tr_generate_testrun_link=config.getoption('--tr-generate-testrun-link')
             ),
             # Name of plugin instance (allow to be used by other plugins)
             name="pytest-testrail-instance"

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -124,6 +124,7 @@ def pytest_addoption(parser):
     group.addoption(
         '--tr-generate-testrun-link',
         action='store_true',
+        required=False,
         help='Set PYTEST_TESTRAIL_TESTRUN_LINK environment variable with a link to generated TESTRUN \
               for external usage (i.e. can be used in test reports or notifications)'
     )
@@ -158,7 +159,7 @@ def pytest_configure(config):
                 skip_missing=config.getoption('--tr-skip-missing'),
                 milestone_id=config_manager.getoption('tr-milestone-id', 'milestone_id', 'TESTRUN'),
                 custom_comment=config_manager.getoption('tc-custom-comment', 'custom_comment', 'TESTCASE'),
-                tr_generate_testrun_link=config.getoption('--tr-generate-testrun-link')
+                tr_generate_testrun_link=config.getoption('--tr-generate-testrun-link', 'generate_testrun_link', 'TESTRUN')
             ),
             # Name of plugin instance (allow to be used by other plugins)
             name="pytest-testrail-instance"

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -5,6 +5,7 @@ from operator import itemgetter
 import pytest
 import re
 import warnings
+import os
 
 # Reference: http://docs.gurock.com/testrail-api2/reference-statuses
 TESTRAIL_TEST_STATUS = {
@@ -141,7 +142,8 @@ def get_testrail_keys(items):
 class PyTestRailPlugin(object):
     def __init__(self, client, assign_user_id, project_id, suite_id, include_all, cert_check, tr_name,
                  tr_description='', run_id=0, plan_id=0, version='', close_on_complete=False,
-                 publish_blocked=True, skip_missing=False, milestone_id=None, custom_comment=None):
+                 publish_blocked=True, skip_missing=False, milestone_id=None, custom_comment=None,
+                 tr_generate_testrun_link=None):
         self.assign_user_id = assign_user_id
         self.cert_check = cert_check
         self.client = client
@@ -159,6 +161,7 @@ class PyTestRailPlugin(object):
         self.skip_missing = skip_missing
         self.milestone_id = milestone_id
         self.custom_comment = custom_comment
+        self.tr_generate_testrun_link = tr_generate_testrun_link
 
     # pytest hooks
 
@@ -391,6 +394,9 @@ class PyTestRailPlugin(object):
             print('[{}] New testrun created with name "{}" and ID={}'.format(TESTRAIL_PREFIX,
                                                                              testrun_name,
                                                                              self.testrun_id))
+            if self.tr_generate_testrun_link:
+                testrun_url = f"{self.client.base_url}/index.php?/runs/view/{self.testrun_id}"
+                os.environ["PYTEST_TESTRAIL_TESTRUN_LINK"] = testrun_url
 
     def close_test_run(self, testrun_id):
         """

--- a/pytest_testrail/testrail_api.py
+++ b/pytest_testrail/testrail_api.py
@@ -44,6 +44,7 @@ class APIClient:
         '''
         self.user = user
         self.password = password
+        self.base_url = base_url
         self._url = urljoin(base_url, 'index.php?/api/v2/')
         self.headers = kwargs.get('headers', {'Content-Type': 'application/json'})
         self.cert_check = kwargs.get('cert_check', True)


### PR DESCRIPTION
Added parameter that sets `PYTEST_TESTRAIL_TESTRUN_LINK ` environmental variable that contains url to generated TestRail Test Run. 

This environmental variable can be used for reporting purposes (i.e. after running the tests - send slack notification with a link to executed Tests Run)