### PR TITLE
fix a bug where a test would not be closed if it had no results

### DIFF
--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -256,10 +256,10 @@ class PyTestRailPlugin(object):
             else:
                 print('[{}] No data published'.format(TESTRAIL_PREFIX))
 
-            if self.close_on_complete and self.testrun_id:
-                self.close_test_run(self.testrun_id)
-            elif self.close_on_complete and self.testplan_id:
-                self.close_test_plan(self.testplan_id)
+        if self.close_on_complete and self.testrun_id:
+            self.close_test_run(self.testrun_id)
+        elif self.close_on_complete and self.testplan_id:
+            self.close_test_plan(self.testplan_id)
         print('[{}] End publishing'.format(TESTRAIL_PREFIX))
 
     # plugin


### PR DESCRIPTION
Why would a test have no results - in my case if `pytest -xvs` is specified, and the tests error out before getting to any which report to Testrail.  A test run would be opened, and never closed.

This was the easy fix - perhaps a better fix is never opening the test run at all, but this is better than nothing in my opinion.